### PR TITLE
docs(demo): upload and host the example application on Google App Engine

### DIFF
--- a/DEMO.md
+++ b/DEMO.md
@@ -1,0 +1,33 @@
+# Demonstration Application Build/Deploy Instructions
+
+A demonstration application is included with this project so that new users who happen to come across this project can interact with its functionality prior to making an informed decision on whether or not it fits within their use case and requirements.
+
+The demonstration application is hosted on Google App Engine (GAE). Therefore, the Google Cloud Platform tools must be installed and authenticated properly before these instructions can be followed. Please see [this](https://developers.google.com/cloud/sdk/?hl=es#Quick_Start) link for additional information.
+
+**Updates to the live version of the demonstration application hosted on GAE is only possible by the project owners.**
+
+## Instructions
+
+* Build the Dart project with `pub` by running the following command in the repository root:
+
+    ```
+    pub build --mode=release
+    ```
+
+This `pub` command will compile and minify all assets and scripts associated with the project. A `build` folder will be created in the root of the repository which will hold the compiled project artifacts.
+
+* Edit the `app.yaml` file to include the proper version designation in the `version:` key. Version designations must **not** contain a dot (.), therefore, dashes (-) are used as replacements. Versions must mimic their Git release tag counterparts (i.e. a Git release tag of 0.2.0 would become 0-2-0 in the `app.yaml` file).
+
+* Change to the directory above the repository root directory by issuing the following command to the terminal:
+
+    ```
+    cd ..
+    ```
+
+* Upload the compiled project files to GAE by running the following command:
+
+    ```
+    appcfg.py update katex.dart
+    ```
+
+* After the `appcfg` script completes, verify that the application is working at this [link](http://katex-dart-demo.appspot.com/).

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Server-side rendering is not yet supported, but it is planned.
 
 ## Demonstration Application and Benchmarks
 
-TODO
+Please visit the [demonstration application](http://katex-dart-demo.appspot.com/).
 
 ## Usage
 

--- a/app.yaml
+++ b/app.yaml
@@ -1,0 +1,21 @@
+application: katex-dart-demo
+version: 0-2-0
+runtime: python27
+api_version: 1
+threadsafe: false
+handlers:
+- url: /
+  static_files: build/web/index.html
+  upload: build/web/index.html
+- url: /
+  static_dir: build/web
+skip_files:
+- ^(doc/.*)
+- ^(lib/.*)
+- ^(node_modules/.*)
+- ^(packages/.*)
+- ^(scripts/.*)
+- ^(test/.*)
+- ^(tool/.*)
+- ^(web/.*)
+- ^(.*/)?.*~


### PR DESCRIPTION
Create a GAE project for hosting the katex.dart demo application, added demo documentation.

Closes #8
